### PR TITLE
[CI] Remove validation of GH events for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,6 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# HlsKit Pull Request Template

Thank you for contributing to HlsKit! Whether you’re submitting changes here, forking the project, or building extensions, you’re part of our community. We’d love for you to share your work with us—let’s build something great together!

> By submitting this pull request, I agree to the [HlsKit Contributor License Agreement (CLA)](../CLA.md), which ensures our ecosystem thrives under LGPLv3.  
> Everyone modifying HlsKit is a contributor! We encourage you to license your changes under LGPLv3 and make them available to others, fostering collaboration across the community.

## Description

Remove validation of GH events for deployment workflow

## Changes Made

Just removed the `if: github.event_name == 'release' && github.event.action == 'published'` line from the deployment workflow

## Acceptance Criteria

It should allow the deployment of hlskit-rs to crates.io through GH Actions

## Test Plans

Tested using ACT

## Checklist

- [x] I’ve followed [Rust’s official style guidelines](https://doc.rust-lang.org/1.0.0/style/) and ran `rustfmt`.
- [x] My code is clean, well-documented, and tested (unit and/or integration tests added where applicable).
- [x] I’ve used the custom errors in `tools/hlskit_error.rs` for error handling.
- [x] My async functions are marked and awaited correctly using `tokio`.
- [x] For major changes, I’ve discussed this in an issue first (link: #<issue-number>).
- [x] I’ve reviewed the [project structure](#project-structure) and placed my changes in the appropriate modules.

