### PR TITLE
[Feature] File Path API for Reading Input Files

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,8 +2,9 @@ name: HlsKit PR Validation
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
+      - "**"
 
 jobs:
   build-and-test:

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -43,12 +43,12 @@ use hlskit::{
     models::hls_video_processing_settings::{
         FfmpegVideoProcessingPreset, HlsVideoProcessingSettings,
     },
-    process_video,
+    process_video, process_video_from_path,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting video processing");
+    println!("Processing video from memory");
 
     let path = env::current_dir()?;
     println!("Current directory: {}", path.display());
@@ -86,11 +86,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
+    println!("Processing video from file path");
+
+    let result2 = process_video_from_path(
+        "src/sample.mp4",
+        vec![
+            HlsVideoProcessingSettings::new(
+                (1920, 1080),
+                28,
+                None, // no custom audio code - defaulting to AAC
+                None, // no custom audio bitrate
+                FfmpegVideoProcessingPreset::Fast,
+            ),
+            HlsVideoProcessingSettings::new(
+                (1280, 720),
+                28,
+                None, // no custom audio code - defaulting to AAC
+                None, // no custom audio bitrate
+                FfmpegVideoProcessingPreset::Fast,
+            ),
+            HlsVideoProcessingSettings::new(
+                (854, 480),
+                28,
+                None, // no custom audio code - defaulting to AAC
+                None, // no custom audio bitrate
+                FfmpegVideoProcessingPreset::Fast,
+            ),
+        ],
+    )
+    .await?;
+
     println!("Video processing completed successfully");
 
     println!(
         "Video master m3u8 file data: {:#?}",
         result.master_m3u8_data
+    );
+
+    println!(
+        "Video master m3u8 file data: {:#?}",
+        result2.master_m3u8_data
     );
 
     Ok(())

--- a/hlskit-rs/src/services/hls_video_processing_service.rs
+++ b/hlskit-rs/src/services/hls_video_processing_service.rs
@@ -207,6 +207,49 @@ pub async fn process_video_profile(
     )
 }
 
+pub async fn process_video_profile_from_path(
+    video_path: &str,
+    resolution: (i32, i32),
+    crf: i32,
+    preset: &str,
+    output_dir: &Path,
+    stream_index: i32,
+) -> Result<HlsVideoResolution, HlsKitError> {
+    let (width, height) = resolution;
+    let segment_filename = format!(
+        "{}/data_{}_%03d.ts",
+        output_dir.to_str().unwrap(),
+        stream_index
+    );
+    let playlist_filename = format!(
+        "{}/playlist_{}.m3u8",
+        output_dir.to_str().unwrap(),
+        stream_index
+    );
+
+    let command = build_ffmpeg_command(
+        video_path,
+        width,
+        height,
+        crf,
+        preset,
+        &segment_filename,
+        &playlist_filename,
+        None,
+        None,
+        None,
+    )?;
+
+    run_ffmpeg_command(&command).await?;
+
+    read_playlist_and_segments(
+        &playlist_filename,
+        &segment_filename,
+        resolution,
+        stream_index,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn process_video_profile_with_encryption(
     input_bytes: Vec<u8>,


### PR DESCRIPTION
# HlsKit Pull Request Template

Thank you for contributing to HlsKit! Whether you’re submitting changes here, forking the project, or building extensions, you’re part of our community. We’d love for you to share your work with us—let’s build something great together!

> By submitting this pull request, I agree to the [HlsKit Contributor License Agreement (CLA)](../CLA.md), which ensures our ecosystem thrives under LGPLv3.  
> Everyone modifying HlsKit is a contributor! We encourage you to license your changes under LGPLv3 and make them available to others, fostering collaboration across the community.

## Description

This new API aims to implement a fancy way to just provide HlsKit a file path instead of the full video, useful for local video processing through CLI wrappers.

## Related Ticket

This PR closes https://github.com/like-engels/hlskit-rs/issues/7

## Changes Made

-  **Added `process_video_from_path` API:**
  - Introduced a new asynchronous function, `process_video_from_path`, to the core library. This function allows processing HLS video directly from a file path, rather than requiring the video to be loaded into memory as bytes.
  - The new function mirrors the existing `process_video` API but accepts a file path and delegates processing to a new helper, `process_video_profile_from_path`.

- **Library Service Updates:**
  - Implemented `process_video_profile_from_path` in the HLS video processing service to handle video processing from a file path.
  - Updated internal logic to support both in-memory and file-path-based video processing.

- **Example Usage:**
  - Updated the example binary to demonstrate both `process_video` (from memory) and the new `process_video_from_path` (from file path) APIs.
  - The example now prints results for both approaches, showing how to use the new API.

## Acceptance Criteria

- Users should be able to provide HlsKit a video file path and obtain the same outcome as if the video content was already provided like in the InMemory API.

## Test Plans

- Tested locally
- Confirmed no regressions in existing FFmpeg functionality.

## Dependencies

No new dependencies.

## Checklist

- [x] I’ve followed [Rust’s official style guidelines](https://doc.rust-lang.org/1.0.0/style/) and ran `rustfmt`.
- [x] My code is clean, well-documented, and tested (unit and/or integration tests added where applicable).
- [x] I’ve used the custom errors in `tools/hlskit_error.rs` for error handling.
- [x] My async functions are marked and awaited correctly using `tokio`.
- [x] For major changes, I’ve discussed this in an issue first (link: #<issue-number>).
- [x] I’ve reviewed the [project structure](#project-structure) and placed my changes in the appropriate modules.

## Additional Notes

No additional notes

---

Thank you for helping make HlsKit an efficient and powerful video streaming toolkit!
