### PR TITLE
[Feature] GStreamer Backend Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -475,6 +476,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -41,12 +41,12 @@ use std::{env, fs::File, io::Read};
 
 use hlskit::{
     VideoInputType,
+    backends::ffmpeg_backend::FfmpegBackend,
     models::hls_video_processing_settings::{
         FfmpegVideoProcessingPreset, HlsVideoProcessingSettings,
     },
     prelude::VideoProcessor,
     process_video, process_video_from_path,
-    services::hls_video_processing_service::FfmpegBackend,
 };
 
 #[tokio::main]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -41,7 +41,7 @@ use std::{env, fs::File, io::Read};
 
 use hlskit::{
     VideoInputType,
-    backends::ffmpeg_backend::FfmpegBackend,
+    backends::{ffmpeg_backend::FfmpegBackend, gstreamer_backend::GStreamerBackend},
     models::hls_video_processing_settings::{
         FfmpegVideoProcessingPreset, HlsVideoProcessingSettings,
     },
@@ -51,6 +51,30 @@ use hlskit::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_profiles = vec![
+        HlsVideoProcessingSettings::new(
+            (1920, 1080),
+            28,
+            None, // no custom audio code - defaulting to AAC
+            None, // no custom audio bitrate
+            FfmpegVideoProcessingPreset::Fast,
+        ),
+        HlsVideoProcessingSettings::new(
+            (1280, 720),
+            28,
+            None, // no custom audio code - defaulting to AAC
+            None, // no custom audio bitrate
+            FfmpegVideoProcessingPreset::Fast,
+        ),
+        HlsVideoProcessingSettings::new(
+            (854, 480),
+            28,
+            None, // no custom audio code - defaulting to AAC
+            None, // no custom audio bitrate
+            FfmpegVideoProcessingPreset::Fast,
+        ),
+    ];
+
     println!("Processing video from memory");
 
     let path = env::current_dir()?;
@@ -61,63 +85,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .read_to_end(&mut buf)?;
 
-    let result = process_video(
-        buf,
-        vec![
-            HlsVideoProcessingSettings::new(
-                (1920, 1080),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (1280, 720),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (854, 480),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-        ],
-    )
-    .await?;
+    let result = process_video(buf.clone(), output_profiles.clone()).await?;
 
     println!("Processing video from file path");
 
-    let result2 = process_video_from_path(
-        "src/sample.mp4",
-        vec![
-            HlsVideoProcessingSettings::new(
-                (1920, 1080),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (1280, 720),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (854, 480),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-        ],
-    )
-    .await?;
+    let result2 = process_video_from_path("src/sample.mp4", output_profiles.clone()).await?;
 
     println!("Video processing completed successfully");
 
@@ -137,35 +109,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_video_input(hlskit::VideoInputType::FilePath(
             "src/sample.mp4".to_string(),
         ))
-        .with_output_profiles(vec![
-            HlsVideoProcessingSettings::new(
-                (1920, 1080),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (1280, 720),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-            HlsVideoProcessingSettings::new(
-                (854, 480),
-                28,
-                None, // no custom audio code - defaulting to AAC
-                None, // no custom audio bitrate
-                FfmpegVideoProcessingPreset::Fast,
-            ),
-        ])
+        .with_output_profiles(output_profiles.clone())
+        .process_video()
+        .await?;
+
+    let result4 = VideoProcessor::<FfmpegBackend, VideoInputType>::new()
+        .with_video_input(VideoInputType::InMemoryFile(buf.clone()))
+        .with_output_profiles(output_profiles.clone())
         .process_video()
         .await?;
 
     println!(
         "Video master m3u8 file data: {:#?}",
         result3.master_m3u8_data
+    );
+
+    println!(
+        "Video master m3u8 file data: {:#?}",
+        result4.master_m3u8_data
+    );
+
+    let result5 = VideoProcessor::<GStreamerBackend, VideoInputType>::new()
+        .with_video_input(hlskit::VideoInputType::FilePath(
+            "src/sample.mp4".to_string(),
+        ))
+        .with_output_profiles(output_profiles.clone())
+        .process_video()
+        .await?;
+
+    let result6 = VideoProcessor::<GStreamerBackend, VideoInputType>::new()
+        .with_video_input(VideoInputType::InMemoryFile(buf.clone()))
+        .with_output_profiles(output_profiles.clone())
+        .process_video()
+        .await?;
+
+    println!(
+        "Video master m3u8 file data: {:#?}",
+        result5.master_m3u8_data
+    );
+
+    println!(
+        "Video master m3u8 file data: {:#?}",
+        result6.master_m3u8_data
     );
 
     Ok(())

--- a/hlskit-rs/Cargo.toml
+++ b/hlskit-rs/Cargo.toml
@@ -27,3 +27,4 @@ futures = { version = "0.3.31", features = ["futures-executor", "thread-pool"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["process", "io-util"] }
+tracing = "0.1.41"

--- a/hlskit-rs/src/backends/ffmpeg_backend.rs
+++ b/hlskit-rs/src/backends/ffmpeg_backend.rs
@@ -47,8 +47,8 @@ use crate::{
         hls_video::HlsVideoResolution, hls_video_processing_settings::HlsVideoProcessingSettings,
     },
     tools::{
-        ffmpeg_command_builder::{FfmpegCommandBuilder, HlsOutputEncryptionConfig},
-        hlskit_error::HlsKitError,
+        ffmpeg_command_builder::FfmpegCommandBuilder, hlskit_error::HlsKitError,
+        internals::hls_output_config::HlsOutputEncryptionConfig,
         segment_tools::read_playlist_and_segments,
     },
     traits::video_processing_backend::VideoProcessingBackend,

--- a/hlskit-rs/src/backends/ffmpeg_backend.rs
+++ b/hlskit-rs/src/backends/ffmpeg_backend.rs
@@ -38,31 +38,22 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
-use std::fs::File;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::{path::Path, process::Stdio};
+
 use tokio::process::Command;
 
-use crate::models::hls_video::HlsVideoSegment;
-use crate::models::hls_video_processing_settings::HlsVideoProcessingSettings;
-use crate::tools::ffmpeg_command_builder::HlsOutputEncryptionConfig;
-use crate::VideoProcessorEncryptionSettings;
 use crate::{
-    models::hls_video::HlsVideoResolution,
-    tools::{ffmpeg_command_builder::FfmpegCommandBuilder, hlskit_error::HlsKitError},
+    models::{
+        hls_video::HlsVideoResolution, hls_video_processing_settings::HlsVideoProcessingSettings,
+    },
+    tools::{
+        ffmpeg_command_builder::{FfmpegCommandBuilder, HlsOutputEncryptionConfig},
+        hlskit_error::HlsKitError,
+        segment_tools::read_playlist_and_segments,
+    },
+    traits::video_processing_backend::VideoProcessingBackend,
+    VideoProcessorEncryptionSettings,
 };
-
-pub trait VideoProcessingBackend {
-    fn process_profile(
-        &self,
-        input: String,
-        profile: &HlsVideoProcessingSettings,
-        output_dir: &Path,
-        stream_index: i32,
-        encryption: Option<&VideoProcessorEncryptionSettings>,
-    ) -> impl std::future::Future<Output = Result<HlsVideoResolution, HlsKitError>>;
-}
 
 #[derive(Default)]
 pub struct FfmpegBackend;
@@ -152,44 +143,4 @@ async fn run_ffmpeg_command(command: &[String]) -> Result<(), HlsKitError> {
         });
     }
     Ok(())
-}
-
-fn read_playlist_and_segments(
-    playlist_filename: &str,
-    segment_filename: &str,
-    resolution: (i32, i32),
-    stream_index: i32,
-) -> Result<HlsVideoResolution, HlsKitError> {
-    let mut resolution = HlsVideoResolution {
-        resolution,
-        playlist_name: format!("playlist_{stream_index}.m3u8"),
-        playlist_data: Vec::new(),
-        segments: Vec::new(),
-    };
-
-    // Read the playlist file
-    let mut playlist_file = File::open(playlist_filename)?;
-    playlist_file.read_to_end(&mut resolution.playlist_data)?;
-
-    // Read all segment files
-    let mut segment_index = 0;
-    loop {
-        let segment_path = segment_filename.replace("%03d", &format!("{segment_index:03}"));
-        if !PathBuf::from(&segment_path).exists() {
-            break;
-        }
-
-        let mut segment_file = File::open(&segment_path)?;
-        let mut segment_data = Vec::new();
-        segment_file.read_to_end(&mut segment_data)?;
-
-        let segment = HlsVideoSegment {
-            segment_name: format!("data_{stream_index}_{segment_index:03}.ts"),
-            segment_data,
-        };
-        resolution.segments.push(segment);
-        segment_index += 1;
-    }
-
-    Ok(resolution)
 }

--- a/hlskit-rs/src/backends/gstreamer_backend.rs
+++ b/hlskit-rs/src/backends/gstreamer_backend.rs
@@ -109,7 +109,7 @@ impl VideoProcessingBackend for GStreamerBackend {
             })
             .collect();
 
-        run_command(&gtreamer_pipeline).await?;
+        run_command(gtreamer_pipeline).await?;
 
         let resolution = read_playlist_and_segments(
             &playlist_filename,

--- a/hlskit-rs/src/backends/gstreamer_backend.rs
+++ b/hlskit-rs/src/backends/gstreamer_backend.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+ * Copyright © 2025 The HlsKit Project
+ *
+ * This software is licensed under the GNU Lesser General Public License v3.0 (LGPLv3).
+ * All contributions adhere to the LGPLv3 and the HlsKit Contributor License Agreement (CLA).
+ * A copy of the LGPLv3 can be found at https://www.gnu.org/licenses/lgpl-3.0.html
+ *
+ * HlsKit Contributor License Agreement
+ *
+ * By contributing to or modifying HlsKit, you agree to the following terms:
+ *
+ * 1. Collective Ownership:
+ * The HlsKit project incorporates original code and all contributions as a collective work,
+ * licensed under LGPLv3. Once submitted, contributions become part of the shared HlsKit
+ * ecosystem and cannot be reclaimed, reassigned, or withdrawn. Contributions to your own
+ * forks remain yours unless submitted here, at which point they join this collective whole under LGPLv3.
+ *
+ * 2. Definition of Contribution:
+ * You are considered a contributor if you modify the library in any form (including forks,
+ * wrappers, libraries, or extensions that alter its behavior), whether or not you submit
+ * your changes directly to this repository. All such modifications are part of the broader
+ * HlsKit ecosystem and are subject to this CLA.
+ *
+ * 3. Distribution of Modifications:
+ * If you distribute a modified version of HlsKit, you must license your modifications under
+ * LGPLv3 (with source code available as required by the license) and ensure they are
+ * adoptable by the HlsKit ecosystem (publicly available and compatible).
+ *
+ * 4. Networked Use of Modifications:
+ * If you use a modified version of HlsKit in a networked application, you must provide the
+ * source code of your modifications under LGPLv3 and notify the HlsKit project
+ * (e.g., via email to [higashikataengels@icloud.com]). This does not apply to the use of
+ * the unmodified library in proprietary software, which remains permissible under LGPLv3.
+ *
+ * 5. Scope:
+ * These terms apply to all contributions and modifications derived from the HlsKit project.
+ * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
+ */
+
+use std::{path::Path, process::Stdio};
+
+use tokio::process::Command;
+
+use crate::{
+    models::{
+        hls_video::HlsVideoResolution, hls_video_processing_settings::HlsVideoProcessingSettings,
+    },
+    tools::{
+        gstreamer_command_builder::GStreamerCommandBuilder, hlskit_error::HlsKitError,
+        internals::hls_output_config::HlsOutputEncryptionConfig,
+        segment_tools::read_playlist_and_segments,
+    },
+    traits::video_processing_backend::VideoProcessingBackend,
+    VideoProcessorEncryptionSettings,
+};
+
+#[derive(Default)]
+pub struct GStreamerBackend;
+
+impl VideoProcessingBackend for GStreamerBackend {
+    async fn process_profile(
+        &self,
+        input: String,
+        profile: &HlsVideoProcessingSettings,
+        output_dir: &Path,
+        stream_index: i32,
+        encryption: Option<&VideoProcessorEncryptionSettings>,
+    ) -> Result<HlsVideoResolution, HlsKitError> {
+        let (width, height) = profile.resolution;
+
+        let segment_filename = format!(
+            "{}/data_{}_%03d.ts",
+            output_dir.to_str().unwrap(),
+            stream_index
+        );
+
+        let playlist_filename = format!(
+            "{}/playlist_{}.m3u8",
+            output_dir.to_str().unwrap(),
+            stream_index
+        );
+
+        let encryption_settings = encryption.map(|enc| HlsOutputEncryptionConfig {
+            encryption_key_path: enc.encryption_key_path.clone(),
+            iv: enc.iv.clone(),
+        });
+
+        let encryption_key_url = encryption.map(|enc| enc.encryption_key_url.as_str());
+
+        let command = GStreamerCommandBuilder::new()
+            .input(&input)
+            .dimensions(width, height)
+            .bitrate(profile.constant_rate_factor)
+            .enable_hls(
+                &segment_filename,
+                None, // Default playlist type
+                encryption_key_url,
+                encryption_settings,
+                10, // Segment duration in seconds
+            )
+            .output(&playlist_filename)
+            .build()?;
+
+        run_gstreamer_command(&command).await?;
+
+        let resolution = read_playlist_and_segments(
+            &playlist_filename,
+            &segment_filename,
+            profile.resolution,
+            stream_index,
+        )?;
+
+        Ok(resolution)
+    }
+}
+
+async fn run_gstreamer_command(command: &[String]) -> Result<(), HlsKitError> {
+    let process = Command::new(&command[0])
+        .args(&command[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| HlsKitError::GstreamerError {
+            error: e.to_string(),
+        })?;
+
+    let output = process
+        .wait_with_output()
+        .await
+        .map_err(|e| HlsKitError::GstreamerError {
+            error: format!("Failed to capture GStreamer output: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(HlsKitError::GstreamerError {
+            error: format!("GStreamer failed: {stderr}"),
+        });
+    }
+    Ok(())
+}

--- a/hlskit-rs/src/backends/mod.rs
+++ b/hlskit-rs/src/backends/mod.rs
@@ -38,7 +38,5 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
-pub mod ffmpeg_command_builder;
-pub mod hlskit_error;
-pub mod m3u8_tools;
-pub mod segment_tools;
+pub mod ffmpeg_backend;
+pub mod gstreamer_backend;

--- a/hlskit-rs/src/lib.rs
+++ b/hlskit-rs/src/lib.rs
@@ -50,14 +50,15 @@ use models::{
 use tempfile::TempDir;
 use tools::{hlskit_error::HlsKitError, m3u8_tools::generate_master_playlist};
 
+use crate::backends::ffmpeg_backend::FfmpegBackend;
+use crate::traits::video_processing_backend::VideoProcessingBackend;
 use crate::{
-    services::hls_video_processing_service::{FfmpegBackend, VideoProcessingBackend},
     tools::hlskit_error::VideoValidatableErrors,
     traits::video_validatable::{VideoInputPathGuard, VideoValidatable},
 };
 
+pub mod backends;
 pub mod models;
-pub mod services;
 pub mod tools;
 pub mod traits;
 
@@ -309,9 +310,10 @@ pub mod prelude {
             hls_video::{HlsVideo, HlsVideoResolution},
             hls_video_processing_settings::HlsVideoProcessingSettings,
         },
-        services::hls_video_processing_service::VideoProcessingBackend,
         tools::{hlskit_error::HlsKitError, m3u8_tools::generate_master_playlist},
-        traits::video_validatable::VideoValidatable,
+        traits::{
+            video_processing_backend::VideoProcessingBackend, video_validatable::VideoValidatable,
+        },
         VideoProcessorEncryptionSettings,
     };
 

--- a/hlskit-rs/src/tools/ffmpeg_command_builder.rs
+++ b/hlskit-rs/src/tools/ffmpeg_command_builder.rs
@@ -40,7 +40,10 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::tools::hlskit_error::FfmpegCommandBuilderError;
+use crate::tools::{
+    hlskit_error::FfmpegCommandBuilderError,
+    internals::hls_output_config::{HlsOutputConfig, HlsOutputEncryptionConfig},
+};
 
 #[derive(Debug, Default)]
 pub struct FfmpegCommand {
@@ -51,21 +54,6 @@ pub struct FfmpegCommand {
     crf: i32,
     preset: String,
     hls_config: Option<HlsOutputConfig>,
-}
-
-#[derive(Debug)]
-struct HlsOutputConfig {
-    segment_filename_pattern: String,
-    playlist_type: Option<String>,
-    encryption_config: Option<HlsOutputEncryptionConfig>,
-    base_url: Option<String>,
-    hls_time: i32,
-}
-
-#[derive(Debug)]
-pub struct HlsOutputEncryptionConfig {
-    pub encryption_key_path: String,
-    pub iv: Option<String>,
 }
 
 impl FfmpegCommand {

--- a/hlskit-rs/src/tools/gstreamer_command_builder.rs
+++ b/hlskit-rs/src/tools/gstreamer_command_builder.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+ * Copyright © 2025 The HlsKit Project
+ *
+ * This software is licensed under the GNU Lesser General Public License v3.0 (LGPLv3).
+ * All contributions adhere to the LGPLv3 and the HlsKit Contributor License Agreement (CLA).
+ * A copy of the LGPLv3 can be found at https://www.gnu.org/licenses/lgpl-3.0.html
+ *
+ * HlsKit Contributor License Agreement
+ *
+ * By contributing to or modifying HlsKit, you agree to the following terms:
+ *
+ * 1. Collective Ownership:
+ * The HlsKit project incorporates original code and all contributions as a collective work,
+ * licensed under LGPLv3. Once submitted, contributions become part of the shared HlsKit
+ * ecosystem and cannot be reclaimed, reassigned, or withdrawn. Contributions to your own
+ * forks remain yours unless submitted here, at which point they join this collective whole under LGPLv3.
+ *
+ * 2. Definition of Contribution:
+ * You are considered a contributor if you modify the library in any form (including forks,
+ * wrappers, libraries, or extensions that alter its behavior), whether or not you submit
+ * your changes directly to this repository. All such modifications are part of the broader
+ * HlsKit ecosystem and are subject to this CLA.
+ *
+ * 3. Distribution of Modifications:
+ * If you distribute a modified version of HlsKit, you must license your modifications under
+ * LGPLv3 (with source code available as required by the license) and ensure they are
+ * adoptable by the HlsKit ecosystem (publicly available and compatible).
+ *
+ * 4. Networked Use of Modifications:
+ * If you use a modified version of HlsKit in a networked application, you must provide the
+ * source code of your modifications under LGPLv3 and notify the HlsKit project
+ * (e.g., via email to [higashikataengels@icloud.com]). This does not apply to the use of
+ * the unmodified library in proprietary software, which remains permissible under LGPLv3.
+ *
+ * 5. Scope:
+ * These terms apply to all contributions and modifications derived from the HlsKit project.
+ * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
+ */
+
+use std::path::{Path, PathBuf};
+
+use crate::tools::{
+    hlskit_error::GStreamerCommandBuilderError,
+    internals::hls_output_config::{HlsOutputConfig, HlsOutputEncryptionConfig},
+};
+
+#[derive(Debug, Default)]
+pub struct GStreamerCommand {
+    input_path: PathBuf,
+    output_path: PathBuf,
+    width: i32,
+    height: i32,
+    bitrate: i32,
+    hls_config: Option<HlsOutputConfig>,
+}
+
+#[derive(Debug, Default)]
+pub struct GStreamerCommandBuilder {
+    command: GStreamerCommand,
+    has_input: bool,
+    has_output: bool,
+    has_dimensions: bool,
+    has_bitrate: bool,
+    errors: Vec<GStreamerCommandBuilderError>,
+}
+
+impl GStreamerCommandBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn input<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.command.input_path = path.as_ref().to_path_buf();
+        self.has_input = true;
+        self
+    }
+
+    pub fn output<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.command.output_path = path.as_ref().to_path_buf();
+        self.has_output = true;
+        self
+    }
+
+    pub fn dimensions(mut self, width: i32, height: i32) -> Self {
+        if width <= 0 || height <= 0 {
+            self.errors
+                .push(GStreamerCommandBuilderError::InvalidDimensions(
+                    "Width and height must be positive.".to_string(),
+                ));
+        }
+        self.command.width = width;
+        self.command.height = height;
+        self.has_dimensions = true;
+        self
+    }
+
+    pub fn bitrate(mut self, kbps: i32) -> Self {
+        if kbps <= 0 {
+            self.errors
+                .push(GStreamerCommandBuilderError::InvalidBitrate(
+                    "Bitrate must be a positive value.".to_string(),
+                ));
+        }
+        self.command.bitrate = kbps;
+        self.has_bitrate = true;
+        self
+    }
+
+    pub fn enable_hls(
+        mut self,
+        segment_pattern: &str,
+        playlist_type: Option<&str>,
+        base_url: Option<&str>,
+        encryption: Option<HlsOutputEncryptionConfig>,
+        hls_time: i32,
+    ) -> Self {
+        if !segment_pattern.contains('%') {
+            self.errors
+                .push(GStreamerCommandBuilderError::InvalidConfig(
+                    "Segment pattern must contain a printf-style specifier (e.g., %05d)."
+                        .to_string(),
+                ));
+        }
+
+        self.command.hls_config = Some(HlsOutputConfig {
+            segment_filename_pattern: segment_pattern.to_string(),
+            playlist_type: playlist_type.map(String::from),
+            base_url: base_url.map(String::from),
+            encryption_config: encryption,
+            hls_time,
+        });
+
+        self
+    }
+
+    pub fn build(&mut self) -> Result<Vec<String>, GStreamerCommandBuilderError> {
+        if !self.errors.is_empty() {
+            return Err(self.errors.remove(0));
+        }
+
+        if !self.has_input {
+            return Err(GStreamerCommandBuilderError::MissingInput);
+        }
+
+        if !self.has_output && self.command.hls_config.is_none() {
+            return Err(GStreamerCommandBuilderError::MissingOutput);
+        }
+
+        if !self.has_dimensions {
+            return Err(GStreamerCommandBuilderError::InvalidDimensions(
+                "Must specify video dimensions.".to_string(),
+            ));
+        }
+
+        if !self.has_bitrate {
+            return Err(GStreamerCommandBuilderError::InvalidBitrate(
+                "Must specify video bitrate.".to_string(),
+            ));
+        }
+
+        Ok(self.command.to_args())
+    }
+}
+
+impl GStreamerCommand {
+    pub fn to_args(&self) -> Vec<String> {
+        let mut args = vec!["gst-launch-1.0".to_string()];
+
+        args.push("filesrc".to_string());
+        args.push(format!("location={}", self.input_path.display()));
+        args.push("! decodebin".to_string());
+        args.push("! videoconvert ! videoscale".to_string());
+        args.push(format!(
+            "! video/x-raw,width={},height={}",
+            self.width, self.height
+        ));
+        args.push(format!(
+            "! x264enc bitrate={} speed-preset=medium tune=zerolatency",
+            self.bitrate
+        ));
+        args.push("! mpegtsmux".to_string());
+
+        if let Some(hls) = &self.hls_config {
+            args.push("! hlssink".to_string());
+
+            // Derive playlist path from segment pattern
+            if let Some(playlist_path) = hls
+                .segment_filename_pattern
+                .rfind('/')
+                .map(|i| format!("{}.m3u8", &hls.segment_filename_pattern[..i]))
+            {
+                args.push(format!("playlist-location={}", playlist_path));
+            }
+
+            args.push(format!("location={}", hls.segment_filename_pattern));
+            args.push(format!("target-duration={}", hls.hls_time));
+
+            if let Some(enc) = &hls.encryption_config {
+                args.push(format!("key-file={}", enc.encryption_key_path));
+
+                // Use base_url as the prefix to form the full key URI
+                let key_filename = std::path::Path::new(&enc.encryption_key_path)
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy();
+
+                if let Some(base_url) = &hls.base_url {
+                    let mut key_uri = base_url.clone();
+                    if !key_uri.ends_with('/') {
+                        key_uri.push('/');
+                    }
+                    key_uri.push_str(&key_filename);
+                    args.push(format!("key-uri={}", key_uri));
+                } else {
+                    // Fallback to just using the filename
+                    args.push(format!("key-uri={}", key_filename));
+                }
+
+                if let Some(iv) = &enc.iv {
+                    args.push(format!("iv={}", iv));
+                }
+            }
+        } else {
+            args.push("! filesink".to_string());
+            args.push(format!("location={}", self.output_path.display()));
+        }
+
+        args
+    }
+}

--- a/hlskit-rs/src/tools/gstreamer_command_builder.rs
+++ b/hlskit-rs/src/tools/gstreamer_command_builder.rs
@@ -204,14 +204,14 @@ impl GStreamerCommand {
                         key_uri.push('/');
                     }
                     key_uri.push_str(&key_filename);
-                    args.push(format!("key-uri={}", key_uri));
+                    args.push(format!("key-uri={key_uri}"));
                 } else {
                     // Fallback to just using the filename
-                    args.push(format!("key-uri={}", key_filename));
+                    args.push(format!("key-uri={key_filename}"));
                 }
 
                 if let Some(iv) = &enc.iv {
-                    args.push(format!("iv={}", iv));
+                    args.push(format!("iv={iv}"));
                 }
             }
         } else {

--- a/hlskit-rs/src/tools/gstreamer_command_builder.rs
+++ b/hlskit-rs/src/tools/gstreamer_command_builder.rs
@@ -184,14 +184,7 @@ impl GStreamerCommand {
         if let Some(hls) = &self.hls_config {
             args.push("! hlssink".to_string());
 
-            // Derive playlist path from segment pattern
-            if let Some(playlist_path) = hls
-                .segment_filename_pattern
-                .rfind('/')
-                .map(|i| format!("{}.m3u8", &hls.segment_filename_pattern[..i]))
-            {
-                args.push(format!("playlist-location={}", playlist_path));
-            }
+            args.push(format!("playlist-location={}", self.output_path.display()));
 
             args.push(format!("location={}", hls.segment_filename_pattern));
             args.push(format!("target-duration={}", hls.hls_time));

--- a/hlskit-rs/src/tools/hlskit_error.rs
+++ b/hlskit-rs/src/tools/hlskit_error.rs
@@ -76,6 +76,20 @@ pub enum FfmpegCommandBuilderError {
     FfmpegSettingError(String),
 }
 
+#[derive(Debug, Error)]
+pub enum GStreamerCommandBuilderError {
+    #[error("Invalid dimensions: {0}")]
+    InvalidDimensions(String),
+    #[error("Invalid bitrate: {0}")]
+    InvalidBitrate(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Missing input")]
+    MissingInput,
+    #[error("Missing output")]
+    MissingOutput,
+}
+
 #[derive(Error, Debug)]
 pub enum HlsKitError {
     #[error(transparent)]
@@ -83,11 +97,15 @@ pub enum HlsKitError {
     #[error(transparent)]
     FFMPEGBUILDER(#[from] FfmpegCommandBuilderError),
     #[error(transparent)]
+    GSTREAMERBUILDER(#[from] GStreamerCommandBuilderError),
+    #[error(transparent)]
     VideoProcessingError(#[from] VideoProcessingErrors),
     #[error(transparent)]
     VideoValidationError(#[from] VideoValidatableErrors),
     #[error("[HlsKit] Failed to spawn Ffmpeg: {error:?}")]
     FfmpegError { error: String },
+    #[error("[HlsKit] Failed to spawn GStreamer: {error:?}")]
+    GstreamerError { error: String },
     #[error("File {file_path:?} not found")]
     FileNotFound { file_path: String },
 }

--- a/hlskit-rs/src/tools/hlskit_error.rs
+++ b/hlskit-rs/src/tools/hlskit_error.rs
@@ -106,6 +106,8 @@ pub enum HlsKitError {
     FfmpegError { error: String },
     #[error("[HlsKit] Failed to spawn GStreamer: {error:?}")]
     GstreamerError { error: String },
+    #[error("Something went wrong while executing the command: {error:?}")]
+    CommandExecutionError { error: String },
     #[error("File {file_path:?} not found")]
     FileNotFound { file_path: String },
 }

--- a/hlskit-rs/src/tools/internals/hls_output_config.rs
+++ b/hlskit-rs/src/tools/internals/hls_output_config.rs
@@ -38,9 +38,17 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
-pub mod ffmpeg_command_builder;
-pub mod gstreamer_command_builder;
-pub mod hlskit_error;
-pub mod internals;
-pub mod m3u8_tools;
-pub mod segment_tools;
+#[derive(Debug, Clone)]
+pub struct HlsOutputConfig {
+    pub segment_filename_pattern: String,
+    pub playlist_type: Option<String>,
+    pub encryption_config: Option<HlsOutputEncryptionConfig>,
+    pub base_url: Option<String>,
+    pub hls_time: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct HlsOutputEncryptionConfig {
+    pub encryption_key_path: String,
+    pub iv: Option<String>,
+}

--- a/hlskit-rs/src/tools/internals/mod.rs
+++ b/hlskit-rs/src/tools/internals/mod.rs
@@ -38,9 +38,4 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
-pub mod ffmpeg_command_builder;
-pub mod gstreamer_command_builder;
-pub mod hlskit_error;
-pub mod internals;
-pub mod m3u8_tools;
-pub mod segment_tools;
+pub mod hls_output_config;

--- a/hlskit-rs/src/traits/mod.rs
+++ b/hlskit-rs/src/traits/mod.rs
@@ -38,4 +38,5 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
+pub mod video_processing_backend;
 pub mod video_validatable;

--- a/hlskit-rs/src/traits/video_processing_backend.rs
+++ b/hlskit-rs/src/traits/video_processing_backend.rs
@@ -38,7 +38,23 @@
  * The use of the unmodified library in proprietary software is governed solely by the LGPLv3.
  */
 
-pub mod ffmpeg_command_builder;
-pub mod hlskit_error;
-pub mod m3u8_tools;
-pub mod segment_tools;
+use std::path::Path;
+
+use crate::{
+    models::{
+        hls_video::HlsVideoResolution, hls_video_processing_settings::HlsVideoProcessingSettings,
+    },
+    tools::hlskit_error::HlsKitError,
+    VideoProcessorEncryptionSettings,
+};
+
+pub trait VideoProcessingBackend {
+    fn process_profile(
+        &self,
+        input: String,
+        profile: &HlsVideoProcessingSettings,
+        output_dir: &Path,
+        stream_index: i32,
+        encryption: Option<&VideoProcessorEncryptionSettings>,
+    ) -> impl std::future::Future<Output = Result<HlsVideoResolution, HlsKitError>>;
+}


### PR DESCRIPTION
# HlsKit Pull Request Template

Thank you for contributing to HlsKit! Whether you’re submitting changes here, forking the project, or building extensions, you’re part of our community. We’d love for you to share your work with us—let’s build something great together!

> By submitting this pull request, I agree to the [HlsKit Contributor License Agreement (CLA)](../CLA.md), which ensures our ecosystem thrives under LGPLv3.  
> Everyone modifying HlsKit is a contributor! We encourage you to license your changes under LGPLv3 and make them available to others, fostering collaboration across the community.

## Description

This PR implements the GStreamer backend as a native choice, so people can use it instead of Ffmpeg if they want to.

Currently GStreamer support is in alpha, so stability is not guaranteed and problems may arise, if you find something weird with the GStreamer backend please let us know.

## Related Ticket

This PR closes #13

## Changes Made

List the specific changes introduced by this PR. Include new files, modified modules, or other relevant updates.

**Example:**  

Summary of Changes

- Introduced a new GStreamer backend alongside the existing FFmpeg backend.
- Added new modules for GStreamer command building and error handling.
- Updated internal tools and configuration structures to support both FFmpeg and GStreamer backends.
- Refactored code to allow backend selection and to generalize video processing logic.
- Completed the implementation of the GStreamer backend, ensuring it is now fully working and integrated.
- Refactored command execution for both backends to use a unified command runner, improving maintainability and error handling.
- Updated the example usage to demonstrate both FFmpeg and GStreamer backends, including processing from both file paths and in-memory buffers.
- Added the `tracing` crate for improved debugging and observability.
- Cleaned up and streamlined code, removing backend-specific command runners in favor of a shared utility.
- Ensured encryption and HLS output configuration are handled consistently across both backends.

**What this means:**  
The project now supports both FFmpeg and GStreamer as interchangeable video processing backends. This makes the library more flexible and extensible for different environments and user preferences. The codebase is also more maintainable, with unified command execution and improved error handling. The example code demonstrates how to use both backends, making it easier for users to adopt the new functionality.

## Acceptance Criteria

- Users can toggle between FFmpeg and GStreamer backends.  
- Output playlists and segments are identical across both backends.  

## Test Plans

- Manually tested playlist output integrity with sample MP4 files using both backends.  
- Confirmed no regressions in existing FFmpeg functionality.

## Dependencies

- the tracing crate was added for better debugging and instrumenting

## Checklist

- [x] I’ve followed [Rust’s official style guidelines](https://doc.rust-lang.org/1.0.0/style/) and ran `rustfmt`.
- [x] My code is clean, well-documented, and tested (unit and/or integration tests added where applicable).
- [x] I’ve used the custom errors in `tools/hlskit_error.rs` for error handling.
- [x] My async functions are marked and awaited correctly using `tokio`.
- [x] For major changes, I’ve discussed this in an issue first (link: #<issue-number>).
- [x] I’ve reviewed the [project structure](#project-structure) and placed my changes in the appropriate modules.

## Additional Notes

No additional notes

---

Thank you for helping make HlsKit an efficient and powerful video streaming toolkit!
